### PR TITLE
add address class to define the anchor's style

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -281,6 +281,11 @@ footer .container-fluid {
     font-family: 'Inter', sans-serif;
 }
 
+footer .address a {
+    color: rgb(221, 84, 29);
+    text-decoration: none;
+}
+
 .preloading {
     position: fixed;
     top: 0;


### PR DESCRIPTION
# 📝 Description

I see on the footer section that the email address has different color than others and is underlined as well. So, I added new class named address in the footer class to define the anchor's style.

🔧 Fixes #(issue)

<hr/>  

### 📷 Provide related Screenshot/Gifs if any.

**Before :** 

**Home Page**
![Screenshot_65](https://user-images.githubusercontent.com/29436427/135703362-796fc43c-a043-40e2-94db-31f14965d0fe.png)

**Trending Page**
![Screenshot_66](https://user-images.githubusercontent.com/29436427/135703368-f150da29-a2f7-47b8-b876-5ddc36b4cf9a.png)

**After :** 

**Home Page**
![Screenshot_68](https://user-images.githubusercontent.com/29436427/135703380-130f943d-27d5-4056-b482-dfbde10d120b.png)

**Trending Page**
![Screenshot_69](https://user-images.githubusercontent.com/29436427/135703383-bb46cf30-ce58-43aa-9a88-78dcd4277701.png)

<hr/>  

- [x] I have performed a self-review of my own code.
- [x] I'm a contributor in Hacktoberfest'21.
