### PR TITLE
Fixed the QTY Field

### DIFF
--- a/product.html
+++ b/product.html
@@ -134,13 +134,14 @@
     <script>
         const increase_btn = document.querySelector("#quantity_inc_button");
         const decrease_btn = document.querySelector("#quantity_dec_button");
-        let qty_val = document.querySelector("#quantity_input").value
         
         increase_btn.addEventListener("click", function(){
+              let qty_val = document.querySelector("#quantity_input").value
               document.querySelector("#quantity_input").value = parseInt(qty_val) + 1;
         });
         
         decrease_btn.addEventListener("click", function(){
+              let qty_val = document.querySelector("#quantity_input").value
               document.querySelector("#quantity_input").value = parseInt(qty_val) - 1;
         });
     </script>


### PR DESCRIPTION
# 📝 Description

In this GitHub repo in the **`products.html`** page, there is a QTY filed.  As per functionality, the QTY field must only take `numeric` values instead of `Alphabet` values but at present, we can see that it is accepting both `Alphabets` and `Numbers`. And also increase and decreasing QTY is also not working. So, I've forked this repo and fixed those issues

🔧 Fixes #(issue)
1. QTY Field restricted to only numeric input
2. Added the increase button click functionality on the QTY field
3. Added the decrease button click functionality on the QTY field
4. Formatted some codes as standard codes

<hr/>  

### 📷 Some screenshots
#### Before:
![before](https://user-images.githubusercontent.com/55192016/138038990-c6a0c193-63eb-4f43-992f-c641bd724feb.png)

#### After:
![after](https://user-images.githubusercontent.com/55192016/138039315-1de11448-2736-41bb-a9f9-d97d349140cd.png)

<hr/>  

- [x] I have performed a self-review of my own code.
- [x] I'm a contributor in Hacktoberfest'21.
